### PR TITLE
Added filter class parameter

### DIFF
--- a/resources/views/filters/dropdown-filter.blade.php
+++ b/resources/views/filters/dropdown-filter.blade.php
@@ -1,4 +1,4 @@
-<select class="form-control" name="filters[{{ $name }}]" v-model="filters['{{ $name }}']" v-on:change="filter(true)">
+<select class="{{ $cssClass }}" name="filters[{{ $name }}]" v-model="filters['{{ $name }}']" v-on:change="filter(true)">
     <option value=""></option>
     @foreach ($items as $k => $v)
         <option value="{{ $k }}">{{ $v }}</option>

--- a/resources/views/filters/text-filter.blade.php
+++ b/resources/views/filters/text-filter.blade.php
@@ -1,5 +1,5 @@
 <input type="text"
-       class="form-control"
+       class="{{ $cssClass }}"
        value="{{ $value }}"
        name="filters[{{ $name }}]"
        v-model="filters['{{ $name }}']"

--- a/resources/views/renderers/default.blade.php
+++ b/resources/views/renderers/default.blade.php
@@ -2,6 +2,9 @@
 /**
 * @var \Woo\GridView\GridView $grid
 **/
+    use Woo\GridView\GridView;$paginator = $grid->getPagination();
+    $thisStart = 1 + ($paginator->currentPage() - 1) * $paginator->perPage();
+    $thisEnd = $paginator->currentPage() * $paginator->perPage()
 @endphp
 
 <div class="grid-view-container">
@@ -14,7 +17,9 @@
     >
         <div>
             @include('woo_gridview::grid-form')
-
+            @if ($paginator->hasPages())
+                <div class="summary">Displaying {{$thisStart}}-{{$thisEnd}} of {{$paginator->total()}} results.</div>
+            @endif
             <table {!! $grid->compileTableHtmlOptions() !!}>
                 <thead>
                     <tr>
@@ -30,28 +35,27 @@
                             </th>
                         @endforeach
                     </tr>
-                </thead>
-                <tbody>
                     @if ($grid->showFilters)
                         <tr>
                             @foreach ($grid->columns as $column)
-                                <td>
+                                <th>
                                     @if ($column->filter)
-                                       {!! $column->filter->render($grid) !!}
+                                        {!! $column->filter->render($grid) !!}
                                     @endif
-                                </td>
+                                </th>
                             @endforeach
                         </tr>
                     @endif
-
-                    @forelse ($grid->getPagination()->items() as $row)
-                        <tr>
-                            @foreach ($grid->columns as $column)
-                                <td {!! $column->compileContentHtmlOptions(['model' => $row]) !!}>
-                                    {!! $column->renderValue($row) !!}
-                                </td>
-                            @endforeach
-                        </tr>
+                </thead>
+                <tbody>
+                @forelse ($grid->getPagination()->items() as $row)
+                    <tr>
+                        @foreach ($grid->columns as $column)
+                            <td {!! $column->compileContentHtmlOptions(['model' => $row]) !!}>
+                                {!! $column->renderValue($row) !!}
+                            </td>
+                        @endforeach
+                    </tr>
                     @empty
                         <tr>
                             <td colspan="{{ count($grid->columns) }}" class="text-center">
@@ -71,7 +75,7 @@
 </div>
 
 @if ($grid->standaloneVue)
-<script src="/vendor/grid-view/grid-view.bundle.js"></script>
+<script src="{{ asset('vendor/grid-view/grid-view.bundle.js')  }}"></script>
 <script>
     window.GridViewShared = @json([]);
     new WooGridView('#grid-{{ $grid->getId() }}');

--- a/src/Filters/BaseFilter.php
+++ b/src/Filters/BaseFilter.php
@@ -10,9 +10,13 @@ abstract class BaseFilter
     use Configurable;
 
     public $name;
+    public $cssClass = 'form-control';
 
     public function __construct(array $config)
     {
+        if (!empty($config['cssClass'])) {
+            $config['cssClass'] .= ' '.$this->cssClass;
+        }
         $this->loadConfig($config);
     }
 

--- a/src/Filters/DropdownFilter.php
+++ b/src/Filters/DropdownFilter.php
@@ -24,6 +24,7 @@ class DropdownFilter extends BaseFilter
             'name' => $this->name,
             'value' => $grid->getRequest()->filters[$this->name] ?? '',
             'items' => $this->items,
+            'cssClass' => $this->cssClass,
         ]);
     }
 }

--- a/src/Filters/TextFilter.php
+++ b/src/Filters/TextFilter.php
@@ -11,6 +11,7 @@ class TextFilter extends BaseFilter
         return view('woo_gridview::filters.text-filter', [
             'name' => $this->name,
             'value' => $grid->getRequest()->filters[$this->name] ?? '',
+            'cssClass' => $this->cssClass,
         ]);
     }
 }


### PR DESCRIPTION
This allows to add custom classes to filters (such as `datePicker`) to enable custom filters.

Moved filters into table head, which allows to add bootstrap classes such as `table-stripped` to the table.

Updated blade to use assets function to include the javascript file, as this will break if Laravel is installed inside a subdirectory.

Finally, added the summary line to show the total count of records and records being shown:
ex. "Displaying 1-50 of 726 results."